### PR TITLE
Fix ci release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Archive Web Build
         id: build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: web-build
           path: web/build


### PR DESCRIPTION
Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3 of actions/upload-artifact. Update to v4 is necessary.